### PR TITLE
Specification issuing improvement

### DIFF
--- a/apps/clients/templates/client_detail.html
+++ b/apps/clients/templates/client_detail.html
@@ -48,7 +48,7 @@
                     {{ spec.product.description }}
                 </td>
                 <td class="col-sm-1">
-                <a href="{% url 'products:specification-pdf-render' spec.product.id spec.date_of_issue client.client_name %}">
+                <a href="{% url 'products:specification-pdf-render' spec.id %}">
                 Widok PDF</a>
                 </td>
             {% endfor %}

--- a/apps/products/templates/specification_issue_confirm.html
+++ b/apps/products/templates/specification_issue_confirm.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+
+<div class="card m-2 p-2 rounded" >
+    <div class="header p-2 grey lighten-2">
+        <h3 class="m-2">Specyfikacja została wystawiona</h3>
+    <hr class="border border-default">
+        <p class="m-2">Po wystawieniu specyfikacji powinno nastąpić samoczynne przekierowanie do nowej karty przeglądarki z widokiem
+            specyfikacji.</p>
+        <p class="m-2">Jeśli nie nastąpiło przekierowanie, kliknij w poniższy link:</p>
+    </div>
+     <span>
+            <a href="{% url 'products:product-detail' specification_issued.product.id %}" class="ml-2 mt-3 btn btn-primary">Wstecz</a>
+                <a href="{% url 'products:specification-pdf-render' specification_issued.id %}"
+                class="ml-2 mt-3 btn btn-danger" target="_blank">
+                Zobacz specyfikację w formacie PDF</a>
+        </span>
+</div>
+<script type="text/javascript">
+    window.onload = function() {
+        let url = "{% url 'products:specification-pdf-render' specification_issued.id %}"
+        const tab = window.open(url, '_blank');
+    };
+</script>
+
+{% endblock %}

--- a/apps/products/templates/specification_to_pdf.html
+++ b/apps/products/templates/specification_to_pdf.html
@@ -58,11 +58,11 @@
             <table class="spec-table">
                 <tr>
                     <th>Odbiorca:</th>
-                    <td colspan="6">{{ client_name }}</td>
+                    <td colspan="6">{{ specification_issued.client.client_name }}</td>
                 </tr>
                 <tr>
                     <th>Data:</th>
-                    <td colspan="6">{{ date }}</td>
+                    <td colspan="6">{{ specification_issued.date_of_issue }}</td>
                 </tr>
             </table>
             <br>
@@ -74,68 +74,68 @@
                 </tr>
                 <tr>
                     <th>Średnica wewnętrzna:</th>
-                    <td><p>{{ product.specification.internal_diameter_target }} mm</p></td>
+                    <td><p>{{ specification_issued.internal_diameter_target }} mm</p></td>
                     <td>
-                        <p> + {{ product.specification.internal_diameter_tolerance_top }} mm /
-                            - {{ product.specification.internal_diameter_tolerance_bottom }} mm</p>
+                        <p> + {{ specification_issued.internal_diameter_tolerance_top }} mm /
+                            - {{ specification_issued.internal_diameter_tolerance_bottom }} mm</p>
                     </td>
                 </tr>
                 <tr>
                     <th>Średnica zewnętrzna:</th>
-                    <td><p>{{ product.specification.external_diameter_target }} mm</p></td>
+                    <td><p>{{ specification_issued.external_diameter_target }} mm</p></td>
                     <td>
-                        <p> + {{ product.specification.external_diameter_tolerance_top }} mm /
-                            - {{ product.specification.external_diameter_tolerance_bottom }} mm</p>
+                        <p> + {{ specification_issued.external_diameter_tolerance_top }} mm /
+                            - {{ specification_issued.external_diameter_tolerance_bottom }} mm</p>
                     </td>
                 </tr>
                 <tr>
                     <th>Grubość ścianki:</th>
-                    <td><p>{{ product.specification.wall_thickness_target }} mm</p></td>
+                    <td><p>{{ specification_issued.wall_thickness_target }} mm</p></td>
                     <td>
                     </td>
                 </tr>
                 <tr>
                     <th>Długość:</th>
-                    <td><p>{{ product.specification.length_target }} mm</p></td>
+                    <td><p>{{ specification_issued.length_target }} mm</p></td>
                     <td>
-                        <p> + {{ product.specification.length_tolerance_top }} mm /
-                            - {{ product.specification.length_tolerance_bottom }} mm</p>
+                        <p> + {{ specification_issued.length_tolerance_top }} mm /
+                            - {{ specification_issued.length_tolerance_bottom }} mm</p>
                     </td>
                 </tr>
                 <tr>
                     <th>Wytrzymałość na ściskanie (100 MM):</th>
-                    <td><p>{{ product.specification.flat_crush_resistance_target }} mm</p></td>
+                    <td><p>{{ specification_issued.flat_crush_resistance_target }} mm</p></td>
                     <td>
-                        <p>- {{ product.specification.flat_crush_resistance_tolerance_bottom }} % </p>
+                        <p>- {{ specification_issued.flat_crush_resistance_tolerance_bottom }} % </p>
                     </td>
                 </tr>
                 <tr>
                     <th>Wilgotność:</th>
-                    <td><p>{{ product.specification.moisture_content_target }} mm</p></td>
+                    <td><p>{{ specification_issued.moisture_content_target }} mm</p></td>
                     <td>
-                        <p> + {{ product.specification.moisture_content_tolerance_top }} % /
-                            - {{ product.specification.moisture_content_tolerance_bottom }} % </p>
+                        <p> + {{ specification_issued.moisture_content_tolerance_top }} % /
+                            - {{ specification_issued.moisture_content_tolerance_bottom }} % </p>
                     </td>
                 </tr>
                 <tr>
                     <th>Kolor:</th>
-                    <td colspan="2"><p>{{ product.specification.colour }}</p></td>
+                    <td colspan="2"><p>{{ specification_issued.colour }}</p></td>
                 </tr>
                 <tr>
                     <th>Powierzchnia:</th>
-                    <td colspan="2"><p>{{ product.specification.finish }}</p></td>
+                    <td colspan="2"><p>{{ specification_issued.finish }}</p></td>
                 </tr>
             </table>
             <br>
             <h3 class="label-textarea">Specyfikacja opakowania</h3>
             <div class="spec-textarea">
-                <span>Maksymalna wysokość palety: {{ product.specification.maximum_height_of_pallet }} mm</span><br>
-                <span>Ilość sztuk na palecie: {{ product.specification.quantity_on_the_pallet }} szt.</span><br>
+                <span>Maksymalna wysokość palety: {{ specification_issued.maximum_height_of_pallet }} mm</span><br>
+                <span>Ilość sztuk na palecie: {{ specification_issued.quantity_on_the_pallet }} szt.</span><br>
                 <span>Narożniki palety zostały zabezpieczone kątownikami tekturowymi?
-                    {{ product.specification.get_pallet_protected_with_paper_edges_display }}</span><br>
+                    {{ specification_issued.get_pallet_protected_with_paper_edges_display }}</span><br>
                 <span>Paleta zabezpieczona folią stretch?
-                    {{ product.specification.get_pallet_wrapped_with_stretch_film_display }}</span><br>
-                <span>Gilzy pakowane: {{ product.specification.get_cores_packed_in_display }}</span>
+                    {{ specification_issued.get_pallet_wrapped_with_stretch_film_display }}</span><br>
+                <span>Gilzy pakowane: {{ specification_issued.get_cores_packed_in_display }}</span>
             </div>
             <br>
             <h3 class="label-textarea">Uwagi</h3>
@@ -156,7 +156,7 @@
                     <td>.......................................................</td>
                 </tr>
                 <tr>
-                    <td>Firma Polska Sp. z o.o.</td>
+                    <td>***** Polska Sp. z o.o.</td>
                     <td>&nbsp</td>
                     <td>Odbiorca</td>
                 </tr>

--- a/apps/products/tests/factories.py
+++ b/apps/products/tests/factories.py
@@ -1,7 +1,8 @@
 import factory
 
+from apps.clients.tests.factories import ClientFactory
 from apps.constants import PRODUCT_SAP_DIGITS, FLOAT_DEFAULT, INT_DEFAULT
-from apps.products.models import Product, Specification
+from apps.products.models import Product, Specification, SpecificationIssued
 
 
 class ProductFactory(factory.DjangoModelFactory):
@@ -18,6 +19,46 @@ class SpecificationFactory(factory.DjangoModelFactory):
         model = Specification
 
     product = factory.SubFactory(ProductFactory)
+    internal_diameter_target = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    internal_diameter_tolerance_top = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    internal_diameter_tolerance_bottom = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+
+    external_diameter_target = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    external_diameter_tolerance_top = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    external_diameter_tolerance_bottom = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+
+    wall_thickness_target = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+
+    length_target = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    length_tolerance_top = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    length_tolerance_bottom = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+
+    flat_crush_resistance_target = factory.Sequence(lambda n: INT_DEFAULT + n)
+    flat_crush_resistance_tolerance_bottom = factory.Sequence(lambda n: INT_DEFAULT + n)
+
+    moisture_content_target = factory.Sequence(lambda n: INT_DEFAULT + n)
+    moisture_content_tolerance_top = factory.Sequence(lambda n: INT_DEFAULT + n)
+    moisture_content_tolerance_bottom = factory.Sequence(lambda n: INT_DEFAULT + n)
+
+    colour = factory.Sequence(lambda n: f"test_colour_{n}")
+    finish = factory.Sequence(lambda n: f"test_finish_{n}")
+
+    maximum_height_of_pallet = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
+    quantity_on_the_pallet = factory.Sequence(lambda n: INT_DEFAULT + n)
+    pallet_protected_with_paper_edges = 'Y'
+    pallet_wrapped_with_stretch_film = 'N'
+    cores_packed_in = 'Vertical'
+    remarks = factory.Sequence(lambda n: f"test_remarks_{n}")
+
+
+class SpecificationIssuedFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = SpecificationIssued
+
+    product = factory.SubFactory(ProductFactory)
+    client = factory.SubFactory(ClientFactory)
+    date_of_issue = "4098-12-12"
+
     internal_diameter_target = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
     internal_diameter_tolerance_top = factory.Sequence(lambda n: FLOAT_DEFAULT + n)
     internal_diameter_tolerance_bottom = factory.Sequence(lambda n: FLOAT_DEFAULT + n)

--- a/apps/products/urls.py
+++ b/apps/products/urls.py
@@ -9,7 +9,9 @@ urlpatterns = [
     path('detail/<int:pk>', views.ProductDetailView.as_view(), name='product-detail'),
     path('update/<int:pk>', views.ProductUpdateView.as_view(), name='product-update'),
     path('delete/<int:pk>', views.ProductDeleteView.as_view(), name='product-delete'),
-    path('specification-issue/<int:pk>', views.SpecificationIssueView.as_view(), name='specification-issue'),
-    path('specification-pdf-render/<int:pk>/<str:date>/<str:client_name>', views.SpecificationPdfRenderView.as_view(),
+    path('specification-issue/<int:pk>', views.SpecificationIssueFormView.as_view(), name='specification-issue'),
+    path('specification-issue-confirm/<int:pk>',
+         views.SpecificationIssueConfirmView.as_view(), name='specification-issue-confirm'),
+    path('specification-pdf-render/<int:pk>', views.SpecificationPdfRenderView.as_view(),
          name='specification-pdf-render'),
 ]

--- a/apps/products/views.py
+++ b/apps/products/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import UpdateView, CreateView, DetailView, DeleteView, ListView, FormView
-from django.views.generic.base import View
+from django.views.generic.base import View, TemplateView
 from django.views.generic.detail import SingleObjectMixin
 
 from apps.clients.models import Client
@@ -149,20 +149,12 @@ class SpecificationPdfRenderView(SingleObjectMixin, View):
     """Provide specification issued for the client as
     a html embedded in PDF format.
     """
-    model = Product
+    model = SpecificationIssued
+    context_object_name = 'specification_issued'
 
     def dispatch(self, request, *args, **kwargs):
         self.object = get_object_or_404(self.model, pk=self.kwargs.get('pk'))
         return super().dispatch(request, *args, **kwargs)
-
-    def get_context_data(self, **kwargs):
-        """Put URL params into the response context data"""
-        client_name = self.kwargs.get('client_name')
-        issue_date = self.kwargs.get('date')
-        context = super().get_context_data(**kwargs)
-        context['client_name'] = client_name
-        context['date'] = issue_date
-        return context
 
     def get(self, request, *args, **kwargs):
         """Get specification in embedded pdf format."""
@@ -172,7 +164,7 @@ class SpecificationPdfRenderView(SingleObjectMixin, View):
         return response
 
 
-class SpecificationIssueView(SingleObjectMixin, FormView):
+class SpecificationIssueFormView(SingleObjectMixin, FormView):
     """Provide form for creation specification issued to the client."""
     model = Product
     form_class = SpecificationIssueForm
@@ -214,12 +206,20 @@ class SpecificationIssueView(SingleObjectMixin, FormView):
 
         specification_ss.save()
 
-        return HttpResponseRedirect(reverse_lazy('products:specification-pdf-render',
-                                                 kwargs={'pk': self.object.pk,
-                                                         'date': date_of_issue,
-                                                         'client_name': client.client_name}))
+        return HttpResponseRedirect(reverse_lazy('products:specification-issue-confirm',
+                                                 kwargs={'pk': specification_ss.id, }))
 
     def form_invalid(self, form):
         add_error_messages(request=self.request, forms=[form, ],
                            base_msg=VIEW_MSG['specification']['issue_error'])
         return super().form_invalid(form)
+
+
+class SpecificationIssueConfirmView(SingleObjectMixin, TemplateView):
+    model = SpecificationIssued
+    template_name = "specification_issue_confirm.html"
+    context_object_name = 'specification_issued'
+
+    def dispatch(self, request, *args, **kwargs):
+        self.object = get_object_or_404(self.model, pk=self.kwargs.get('pk'))
+        return super().dispatch(request, *args, **kwargs)

--- a/apps/products/views.py
+++ b/apps/products/views.py
@@ -216,6 +216,7 @@ class SpecificationIssueFormView(SingleObjectMixin, FormView):
 
 
 class SpecificationIssueConfirmView(SingleObjectMixin, TemplateView):
+    """Provide template with confirmation of specification issued was created successfully"""
     model = SpecificationIssued
     template_name = "specification_issue_confirm.html"
     context_object_name = 'specification_issued'


### PR DESCRIPTION
- display page with confirmation of creation after specification was issued successfully
- open pdf view of issued specification in new tab, provide a link inside confirmation page
- update unit tests for specification issuing view